### PR TITLE
Add announcement.url to moves in legacies

### DIFF
--- a/draft/legacies.copld.yaml
+++ b/draft/legacies.copld.yaml
@@ -13,6 +13,12 @@ definitions:
     type: string
     pattern: ^(\*\.)*([a-z0-9\-]+\.)+[a-z0-9\-]+$
 
+  urlish:
+    type: string
+    # right now, after the host and path, anything goes
+    # this will probably get more formal in the future
+    pattern: ^https?://(([a-z0-9\-]+|\*)\.)+[a-z0-9\-]+/
+
 # body #
 
 type: array
@@ -29,3 +35,8 @@ items:
 
       to:
         $ref: "#/definitions/domain"
+
+    announcement.:
+
+      url:
+        $ref: "#/definitions/urlish"

--- a/draft/legacies.json
+++ b/draft/legacies.json
@@ -6,6 +6,10 @@
     "domain": {
       "type": "string",
       "pattern": "^(\\*\\.)*([a-z0-9\\-]+\\.)+[a-z0-9\\-]+$"
+    },
+    "urlish": {
+      "type": "string",
+      "pattern": "^https?://(([a-z0-9\\-]+|\\*)\\.)+[a-z0-9\\-]+/"
     }
   },
   "type": "array",
@@ -24,6 +28,15 @@
         "properties": {
           "to": {
             "$ref": "#/definitions/domain"
+          }
+        },
+        "minimumProperties": 1
+      },
+      "announcement": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "$ref": "#/definitions/urlish"
           }
         },
         "minimumProperties": 1


### PR DESCRIPTION
This removes the last bastion of notes in profile documents, as tracked in #1.